### PR TITLE
Arjan and Lars fixes and optimizations

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -33,6 +33,7 @@ Jinja2 = 2.7.3
 MarkupSafe = 0.23
 mr.developer = 1.31
 nose = 1.3.4
+numpy = 1.8.2
 pbp.recipe.noserunner = 0.2.6
 pb.recipes.pydev = 0.4.5
 pep8 = 1.5.7

--- a/raster_tools/smooth.py
+++ b/raster_tools/smooth.py
@@ -28,12 +28,10 @@ from scipy import signal
 from scipy import ndimage
 import unipath
 
-try:
-    from osgeo import ogr
-    from osgeo import gdal
-except ImportError, _:
-    import ogr
-    import gdal
+from osgeo import ogr
+from osgeo import gdal
+
+gdal.UseExceptions()
 
 logger = logging.getLogger(__name__)
 

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ long_description = '\n\n'.join([
 install_requires = [
     'setuptools',
     'unipath',
+    'numpy',
     ],
 
 tests_require = [


### PR DESCRIPTION
Towards production-ready smooth script. Some todos:
- np.where() instead of gdal_merge.py
- cleanup intermediate files
- an output folder structure like smt/37b/s37bz2_08.tif
- only store diff data compared to ahn2/int, so just enough to fill the gaps